### PR TITLE
Convert ! prefix into > prefix in the text in help.ts

### DIFF
--- a/suggestion-bot/src/commands/help.ts
+++ b/suggestion-bot/src/commands/help.ts
@@ -2,13 +2,13 @@ import Discord from "discord.js";
 
 module.exports = (msg: Discord.Message) => {
   let reply = "```\n";
-  reply += "!suggest <your suggestion here>\n";
+  reply += ">suggest <your suggestion here>\n";
   reply += "  - Adds your suggestion in databse\n";
-  reply += "!list\n";
+  reply += ">list\n";
   reply += "  - Lists all CURRENT suggestions\n";
-  reply += "!list mine\n";
+  reply += ">list mine\n";
   reply += "  - Lists all YOUR suggestions\n";
-  reply += "!vote <number>\n";
+  reply += ">vote <number>\n";
   reply += "  - Vote a suggestion (use after !list)\n";
   reply += "```";
   msg.channel.send(reply);

--- a/suggestion-bot/src/commands/help.ts
+++ b/suggestion-bot/src/commands/help.ts
@@ -9,7 +9,7 @@ module.exports = (msg: Discord.Message) => {
   reply += ">list mine\n";
   reply += "  - Lists all YOUR suggestions\n";
   reply += ">vote <number>\n";
-  reply += "  - Vote a suggestion (use after !list)\n";
+  reply += "  - Vote a suggestion (use after >list)\n";
   reply += "```";
   msg.channel.send(reply);
 };


### PR DESCRIPTION
	modified:   help.ts

In the bot's current `config.json`, the present prefix for bot commands is `>`, and the bot responds to commands like `>help`. But the help command implies that the prefix is `!`. This PR makes a slight change to the help command to be accurate to the actual code.

From:
```ts
  reply += "!suggest <your suggestion here>\n";
  reply += "  - Adds your suggestion in databse\n";
```
To:
```ts
  reply += ">suggest <your suggestion here>\n";
  reply += "  - Adds your suggestion in databse\n";
```

Though it would be better if `help.ts` reads the prefix from the config, so we don't have to change the file every time we change the prefix.